### PR TITLE
UI Turned into Overlay for Prepar3D

### DIFF
--- a/ManagedDashboard.csproj
+++ b/ManagedDashboard.csproj
@@ -35,7 +35,6 @@
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
   </PropertyGroup>
-  
   <!-- Build options -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
     <DebugSymbols>true</DebugSymbols>
@@ -58,11 +57,13 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
-  
   <!-- Library dependency setup -->
   <ItemGroup>
+    <PackageReference Include="Topshelf">
+      <Version>4.3.0</Version>
+    </PackageReference>
     <Reference Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'" Include="LockheedMartin.Prepar3D.SimConnect">
-	<HintPath>C:\Program Files\Lockheed Martin\Prepar3D v5 SDK 5.4.9.28482\lib\SimConnect\managed\LockheedMartin.Prepar3D.SimConnect.Debug.dll</HintPath>
+      <HintPath>C:\Program Files\Lockheed Martin\Prepar3D v5 SDK 5.4.9.28482\lib\SimConnect\managed\LockheedMartin.Prepar3D.SimConnect.Debug.dll</HintPath>
     </Reference>
     <Reference Condition="'$(Configuration)|$(Platform)' == 'Release|x64'" Include="LockheedMartin.Prepar3D.SimConnect">
       <HintPath>C:\Program Files\Lockheed Martin\Prepar3D v5 SDK 5.4.9.28482\lib\SimConnect\managed\LockheedMartin.Prepar3D.SimConnect.dll</HintPath>
@@ -80,31 +81,30 @@
     <Reference Include="PresentationBuildTasks" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <PackageReference Include="HarfBuzzSharp" Version="7.3.0"  />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="7.3.0"  />
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.Win32" Version="7.3.0"  />
-    <PackageReference Include="LiveCharts" Version="0.9.7"  />
-    <PackageReference Include="LiveCharts.WinForms" Version="0.9.7.1"  />
-    <PackageReference Include="LiveCharts.Wpf" Version="0.9.7"  />
-    <PackageReference Include="LiveChartsCore" Version="2.0.0-rc2"  />
-    <PackageReference Include="LiveChartsCore.SkiaSharpView" Version="2.0.0-rc2"  />
-    <PackageReference Include="LiveChartsCore.SkiaSharpView.WinForms" Version="2.0.0-rc2"  />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2"  />
-    <PackageReference Include="OpenTK" Version="3.1.0"  />
-    <PackageReference Include="OpenTK.GLControl" Version="3.1.0"  />
-    <PackageReference Include="SkiaSharp" Version="2.88.6"  />
-    <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.6"  />
-    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.6"  />
-    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.6"  />
-    <PackageReference Include="SkiaSharp.Views.Desktop.Common" Version="2.88.6"  />
-    <PackageReference Include="SkiaSharp.Views.WindowsForms" Version="2.88.6"  />
-    <PackageReference Include="System.Buffers" Version="4.5.1"  />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.3"  />
-    <PackageReference Include="System.Memory" Version="4.5.5"  />
-    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0"  />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.3"  />
+    <PackageReference Include="HarfBuzzSharp" Version="7.3.0" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="7.3.0" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Win32" Version="7.3.0" />
+    <PackageReference Include="LiveCharts" Version="0.9.7" />
+    <PackageReference Include="LiveCharts.WinForms" Version="0.9.7.1" />
+    <PackageReference Include="LiveCharts.Wpf" Version="0.9.7" />
+    <PackageReference Include="LiveChartsCore" Version="2.0.0-rc2" />
+    <PackageReference Include="LiveChartsCore.SkiaSharpView" Version="2.0.0-rc2" />
+    <PackageReference Include="LiveChartsCore.SkiaSharpView.WinForms" Version="2.0.0-rc2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="OpenTK" Version="3.1.0" />
+    <PackageReference Include="OpenTK.GLControl" Version="3.1.0" />
+    <PackageReference Include="SkiaSharp" Version="2.88.6" />
+    <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.6" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.6" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.6" />
+    <PackageReference Include="SkiaSharp.Views.Desktop.Common" Version="2.88.6" />
+    <PackageReference Include="SkiaSharp.Views.WindowsForms" Version="2.88.6" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.3" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.3" />
   </ItemGroup>
-
   <!-- Source code options -->
   <ItemGroup>
     <Compile Include="Dashboard.cs">
@@ -113,8 +113,8 @@
     <Compile Include="Dashboard.Designer.cs">
       <DependentUpon>Dashboard.cs</DependentUpon>
     </Compile>
-    <Compile Include="Program.cs"/>
-    <Compile Include="Properties\AssemblyInfo.cs"/>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <EmbeddedResource Include="Dashboard.resx">
       <SubType>Designer</SubType>
       <DependentUpon>Dashboard.cs</DependentUpon>
@@ -124,19 +124,18 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
       <SubType>Designer</SubType>
     </Compile>
-      <None Include="app.config"/>
-      <None Include="OpenTK.dll.config"/>
-      <None Include="Properties\Settings.settings">
-	<Generator>SettingsSingleFileGenerator</Generator>
-	<LastGenOutput>Settings.Designer.cs</LastGenOutput>
-      </None>
+    <None Include="app.config" />
+    <None Include="OpenTK.dll.config" />
+    <None Include="Properties\Settings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
+    </None>
     <Compile Include="Properties\Settings.Designer.cs">
       <AutoGen>True</AutoGen>
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
   </ItemGroup>
-
   <!-- .NET framework setup -->
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">


### PR DESCRIPTION
The UI Window has been made Top Most of every program, made it full screen at all times and is click-through for use with Prepar3D, and made transparent/see-through to be an overlay over Prepar3D.