### PR TITLE
Implement Show/Hide Feature for Dashboard Overlay

### DIFF
--- a/Dashboard.Designer.cs
+++ b/Dashboard.Designer.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2010-2022 Lockheed Martin Corporation. All rights reserved.
 // Use of this file is bound by the PREPAR3D® SOFTWARE DEVELOPER KIT END USER LICENSE AGREEMENT
 
+using System.Windows.Forms;
+
 namespace Managed_Dashboard
 {
     partial class Form1
@@ -32,9 +34,16 @@ namespace Managed_Dashboard
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Form1));
+
+            // Initialize the buttons
             this.buttonConnect = new System.Windows.Forms.Button();
             this.buttonDisconnect = new System.Windows.Forms.Button();
-            this.SuspendLayout();
+            this.toggleButton = new System.Windows.Forms.Button();
+
+            // Initialize the collapsible panel
+            this.collapsiblePanel = new System.Windows.Forms.Panel();
+            this.collapsiblePanel.Visible = false;
+
             // 
             // buttonConnect
             // 
@@ -46,6 +55,7 @@ namespace Managed_Dashboard
             this.buttonConnect.Text = "Connect to P3D";
             this.buttonConnect.UseVisualStyleBackColor = true;
             this.buttonConnect.Click += new System.EventHandler(this.buttonConnect_Click);
+
             // 
             // buttonDisconnect
             // 
@@ -57,12 +67,28 @@ namespace Managed_Dashboard
             this.buttonDisconnect.Text = "Disconnect from P3D";
             this.buttonDisconnect.UseVisualStyleBackColor = true;
             this.buttonDisconnect.Click += new System.EventHandler(this.buttonDisconnect_Click);
+
+            // 
+            // toggleButton
+            // 
+            this.toggleButton.Location = new System.Drawing.Point(330, 10);
+            this.toggleButton.Margin = new System.Windows.Forms.Padding(4);
+            this.toggleButton.Name = "toggleButton";
+            this.toggleButton.Size = new System.Drawing.Size(150, 38);
+            this.toggleButton.TabIndex = 2;
+            this.toggleButton.Text = "Hide dashboard";
+            this.toggleButton.UseVisualStyleBackColor = true;
+            this.toggleButton.Click += new System.EventHandler(this.TogglePanelsButton_Click);
+
+            
             // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(1030, 800);
+            this.Controls.Add(this.collapsiblePanel);
+            this.Controls.Add(this.toggleButton);
             this.Controls.Add(this.buttonDisconnect);
             this.Controls.Add(this.buttonConnect);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
@@ -72,13 +98,16 @@ namespace Managed_Dashboard
             this.Text = "Managed Dashboard";
             this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.Form1_FormClosed);
             this.ResumeLayout(false);
-
         }
 
         #endregion
 
         private System.Windows.Forms.Button buttonConnect;
         private System.Windows.Forms.Button buttonDisconnect;
+
+        private System.Windows.Forms.Panel collapsiblePanel;
+        private System.Windows.Forms.Button toggleButton;
+
     }
 }
 

--- a/Dashboard.cs
+++ b/Dashboard.cs
@@ -190,6 +190,23 @@ namespace Managed_Dashboard
             magneticHeadingGroupBox.Controls.Add(magneticHeadingChart);
         }
 
+        private void TogglePanelsButton_Click(object sender, EventArgs e)
+        {
+            // Toggle visibility of the collapsible panel
+            if (collapsiblePanel.Visible)
+            {
+                collapsiblePanel.Visible = false; 
+                toggleButton.Text = "Hide dashboard";
+            }
+            else
+            {
+                collapsiblePanel.Visible = true; 
+                toggleButton.Text = "Show dashboard";
+            }
+        }
+
+
+
 
         [DllImport("user32.dll", SetLastError = true)]
         private static extern IntPtr FindWindow(string lpClassName, string lpWindowName);
@@ -254,6 +271,10 @@ namespace Managed_Dashboard
                         this.Left = rect.Left;
                         this.Width = rect.Right - rect.Left;
                         this.Height = rect.Bottom - rect.Top;
+
+                        this.collapsiblePanel.Location = new System.Drawing.Point(0, buttonConnect.Location.Y + buttonConnect.Height + 10); // Set below the buttons with padding
+                        this.collapsiblePanel.Size = new System.Drawing.Size(this.ClientSize.Width, this.ClientSize.Height - (buttonConnect.Height + 20)); // Fill the remaining space below the buttons
+                        this.collapsiblePanel.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right; // Anchors to resize dynamically
 
                         // Update chart sizes to fill the new window dimensions
                         UpdateChartSizes(width, height);

--- a/ManagedDashboard.csproj
+++ b/ManagedDashboard.csproj
@@ -62,10 +62,10 @@
     <PackageReference Include="Topshelf">
       <Version>4.3.0</Version>
     </PackageReference>
-    <Reference Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'" Include="LockheedMartin.Prepar3D.SimConnect">
-      <HintPath>C:\Program Files\Lockheed Martin\Prepar3D v5 SDK 5.4.9.28482\lib\SimConnect\managed\LockheedMartin.Prepar3D.SimConnect.Debug.dll</HintPath>
-    </Reference>
     <Reference Condition="'$(Configuration)|$(Platform)' == 'Release|x64'" Include="LockheedMartin.Prepar3D.SimConnect">
+      <HintPath>C:\Program Files\Lockheed Martin\Prepar3D v5 SDK 5.4.9.28482\lib\SimConnect\managed\LockheedMartin.Prepar3D.SimConnect.dll</HintPath>
+    </Reference>
+    <Reference Include="LockheedMartin.Prepar3D.SimConnect">
       <HintPath>C:\Program Files\Lockheed Martin\Prepar3D v5 SDK 5.4.9.28482\lib\SimConnect\managed\LockheedMartin.Prepar3D.SimConnect.dll</HintPath>
     </Reference>
     <Reference Include="System" />


### PR DESCRIPTION
https://github.com/user-attachments/assets/3d3999e4-0616-41b3-bbe8-4f81202f39f5

Introduces a show/hide feature for the dashboard overlay in our Prepar3D integration. The collapsible panel is initially hidden when the dashboard launches, providing a clean interface for users.

Key Changes:

Added a collapsible panel that can be toggled using a button.
The button text dynamically updates to reflect the current state ("Show dashboard" or "Hide dashboard").
The collapsible panel covers the entire dashboard area, ensuring better visibility and accessibility of data.
Adjusted the layout to synchronize the panel's dimensions with the Prepar3D window.
Implementation Details:

Collapsible Panel: The panel's visibility is controlled via the TogglePanelsButton_Click method, ensuring it covers the dashboard when shown.
Initial State: The panel is set to be hidden on launch, allowing users to focus on the essential dashboard components.
Dynamic Positioning: The dashboard overlays the Prepar3D window and resizes accordingly, providing a consistent user experience.